### PR TITLE
반응형으로 웹 앱의 레이아웃을 root 요소의 크기에 반영하는 기능을 구현하였습니다.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,15 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>in development..</title>
+</head>
+
+<body class="bg-primary-200 h-screen flex justify-center items-center">
+  <div id="root" class="bg-primary-100">
+  </div>
+
+  <script type="module" src="/src/main.tsx"></script>
+</body>
 </html>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,8 +3,49 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
 
-createRoot(document.getElementById('root')!).render(
+const rootEl = document.getElementById('root')!;
+const root = createRoot(rootEl);
+
+/**
+ * root 요소의 크기를 visual viewport에 알맞게 변경하는 함수이다.
+ */
+function adjustRootDimensions(): void {
+  // Visual viewport가 가로 방향 레이아웃을 구성하기에 적합한 너비와 종횡비 값을 가졌는지 확인하기
+  const isLandscapeLayoutSuitable = (): boolean =>
+    568 <= window.innerWidth && 0.81 < window.innerWidth / window.innerHeight;
+
+  let w, h; // 각각 root 요소의 너비 값과 높이 값으로써 설정될 값들이다.
+  if (isLandscapeLayoutSuitable()) {
+    w = Math.max(390, Math.ceil(window.innerWidth * 0.3));
+    h = Math.min(w * 2, window.innerHeight);
+  } else {
+    [w, h] = [window.innerWidth, window.innerHeight];
+  }
+
+  [rootEl.style.width, rootEl.style.height] = [`${w}px`, `${h}px`];
+}
+
+// 처음으로 root 요소의 크기를 조정하고 나서, root(: Root)에 리액트 요소를 렌더링하기
+adjustRootDimensions();
+root.render(
   <StrictMode>
     <App />
   </StrictMode>
 );
+
+let timeoutId = 0;
+/**
+ * root 요소의 크기 변경이 잦은 시간 간격으로 수행되는 것을 방지하는 디바운싱(Debouncing) 함수이다.
+ */
+function debounceAdjustings(): void {
+  if (timeoutId != 0) {
+    clearTimeout(timeoutId);
+  }
+  timeoutId = setTimeout(adjustRootDimensions, 250);
+}
+
+// 화면 크기가 변경될 때
+window.addEventListener('resize', debounceAdjustings);
+
+// 화면 방향이 변경될 때
+screen.orientation.addEventListener('change', debounceAdjustings);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -22,6 +22,11 @@ function adjustRootDimensions(): void {
     [w, h] = [window.innerWidth, window.innerHeight];
   }
 
+  const htmlEl = document.documentElement;
+  htmlEl.style.fontSize =
+    Number(getComputedStyle(htmlEl).fontSize.replace('px', '')) *
+      Math.sqrt(window.innerWidth / 568) +
+    'px';
   [rootEl.style.width, rootEl.style.height] = [`${w}px`, `${h}px`];
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,10 +1,28 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
+    colors: {
+      'primary': {
+        100: '#dce9fc',
+        200: '#bbdef9',
+        300: '#168aad',
+        400: '#1a759f',
+        500: '#1e6091',
+        600: '#184e77',
+      },
+      'secondary': {
+        100: '#eaf8da',
+        200: '#d9ed92',
+        300: '#b5e48c',
+        400: '#99d98c',
+        500: '#76c893',
+        600: '#52b69a',
+      },
+    },
     extend: {},
   },
   plugins: [],


### PR DESCRIPTION
1. Figma의 화면별 디자인/기능정의 페이지에 변수로 저장되어 있는 테마 색상들을 tailwind\.config\.js 파일에 추가하였습니다\.\
   \(색상 숫자는 러프하게 넣었고, 나중에 추가 색상은 50 단위로 사이에 집어 넣을 수 있을 정도로만 고민해봤습니다\.\)
2. 기능을 추가하기 전과 동일하게 리액트 App 컴포넌트에서부터 개발을 시작할 수 있게 코드를 구현하였습니다\.
3. 내일 추가 세팅 완료 후, dev 브랜치로 넘어가기 전이기 때문에 예외적으로 master 브랜치에 직접 PR을 올리게 되었습니다\.

기기별 visual viewport 정보는 [웹사이트](https://viewportsizer.com/devices)를 참고하였습니다\.
천천히 검토 부탁드립니다\.